### PR TITLE
expose binary `bouncer-model-build`

### DIFF
--- a/bin/bouncer-model-build
+++ b/bin/bouncer-model-build
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+const Path = require('path')
+const mkdirp = require('mkdirp')
+const Bossy = require('@hapi/bossy')
+const buildModel = require('../src/build-model')
+
+const Usage = `bouncer-model-build --name <MODEL_NAME> --model <MODEL_PATH> --output <OUTPUT_DIR>`
+
+const Definition = {
+  n: {
+    description: 'Model name',
+    alias: 'name',
+    type: 'string',
+    require: true
+  },
+  m: {
+    description: 'Model .js file path',
+    alias: 'model',
+    type: 'string',
+    require: true,
+    default: './src/index.js'
+  },
+  o: {
+    description: 'Output directory',
+    alias: 'output',
+    type: 'string',
+    require: true,
+    default: 'dist/'
+  }
+}
+
+
+async function main(argv){
+  
+  const parsed = Bossy.parse(Definition, {argv})
+  
+  if(parsed instanceof Error){
+    throw new Error('UsageError')
+  }
+  
+  const modelPath = Path.isAbsolute(parsed.model) ? parsed.model : Path.join(process.cwd(), parsed.model)
+  
+  const outputPath = Path.isAbsolute(parsed.output) ? parsed.output : Path.join(process.cwd(), parsed.output)
+  
+  await mkdirp(outputPath)
+  
+  const compiled = await buildModel({
+    name: parsed.name,
+    modelPath,
+    outputPath
+  })
+  
+  console.log('compiled', compiled.Api.length, 'models to ->', compiled.SchemePath)
+}
+
+// Run main
+main(process.args).catch((error) => {
+
+  let content = ''
+
+  if(error instanceof Error){ content += error.name + ' - ' + error.message + '\n\n'}
+
+  content += Bossy.usage(Definition, Usage)
+  
+  console.log(content)
+  
+  if(process.send){
+    process.send({
+      error: error,
+      output: content
+    })
+  }
+  
+  process.exit()
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@dataparty/bouncer-model",
-  "private": false,
   "version": "1.0.1",
   "description": "Bouncer default actor models",
   "author": "RosHub Inc. <code@roshub.io>",
@@ -14,19 +13,23 @@
     "dist",
     "src"
   ],
+  "bin": {
+    "bouncer-model-build": "./bin/bouncer-model-build"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf dist",
-    "build": "mkdir -p dist; npx -q ./src/build-model.js | tee  ./dist/bouncer-model.json > /dev/null",
-    "postinstall": "mkdir -p dist; npx -q ./src/build-model.js | tee  ./dist/bouncer-model.json > /dev/null"
+    "build": "bouncer-model-build --name bouncer"
   },
   "dependencies": {
+    "@hapi/bossy": "^5.0.0",
     "@octokit/rest": "16.23.2",
     "crypto-random-string": "^3.0.0",
     "debug": "^3.1.0",
     "deep-set": "^1.0.1",
     "hoek": "^5.0.3",
     "json-schema-to-typescript": "^6.0.2",
+    "mkdirp": "^1.0.3",
     "moment": "^2.22.1",
     "mongoose": "5.7.7",
     "mongoose-schema-jsonschema": "1.2.1"

--- a/src/build-model.js
+++ b/src/build-model.js
@@ -1,27 +1,62 @@
 const fs = require('fs')
+const Path = require('path')
 const mongoose = require('mongoose')
 require('mongoose-schema-jsonschema')(mongoose)
 const json2ts = require('json-schema-to-typescript')
 
-const Model = require('./index')
 
-const output = {
-  Api: []
+const buildModel = async function(
+  {
+    name,
+    modelPath='./index.js',
+    outputPath='./dist',
+    buildTypeScript=true
+  }={}
+){
+  const Model = require(modelPath)
+
+  const output = {
+    Api: []
+  }
+  
+  const tsWrites = []
+  const tsOutput = {}
+
+  for(let key in Model.Types){
+    const model = Model.Types[key]
+    const schema = mongoose.Schema(model.Schema)
+    let jsonSchema = schema.jsonSchema()
+
+    jsonSchema.title = model.Type
+
+    output.Api.push(jsonSchema)
+
+    if(buildTypeScript){
+      
+      const tsWrite = json2ts.compile(jsonSchema).then( ts=>{
+        tsOutput[model.Type] = ts
+        const tsPath = Path.join(outputPath, model.Type + '.d.ts')
+        fs.writeFileSync(tsPath, ts)
+      })
+      
+      tsWrites.push(tsWrites)
+      
+    }
+
+  }
+  
+  if(buildTypeScript){ await Promise.all(tsWrites) }
+  
+  const jsonSchemaStr = JSON.stringify(output, null, 2)
+  const jsonSchemaPath = Path.join(outputPath, name+'-model.json')
+  fs.writeFileSync(jsonSchemaPath, jsonSchemaStr)
+  
+  return {
+    SchemePath: jsonSchemaPath,
+    Api: output.Api,
+    JSON: jsonSchemaStr,
+    TypeScript: tsOutput
+  }
 }
 
-for(let key in Model.Types){
-  const model = Model.Types[key]
-  const schema = mongoose.Schema(model.Schema)
-  let jsonSchema = schema.jsonSchema()
-
-  jsonSchema.title = model.Type
-
-  output.Api.push(jsonSchema)
-
-  json2ts.compile(jsonSchema).then( ts=>{
-    fs.writeFileSync('dist/'+model.Type+'.d.ts', ts)
-  })
-
-}
-
-console.log( JSON.stringify(output, null, 2) )
+module.exports = buildModel


### PR DESCRIPTION
## Issues resolved:

- [x] #2  - New bin script `bouncer-model-build` 

```console
$ bouncer-model-build 
Error - UsageError

Usage: bouncer-model-build --name <MODEL_NAME> --model <MODEL_PATH> --output <OUTPUT_DIR>

Options:                   

  -n, --name      Model name (required)
  -m, --model     Model .js file path (./src/index.js) (required)
  -o, --output    Output directory (dist/) (required)
```

Used by downstream dataparty model packages to compile TypeScript and JSONScheme validators.

<!-- 
## Screenshot (optional)
 

## Test (optional)

-->
