### PR TITLE
Fix actors non array crash

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -48,7 +48,7 @@ exports.actor = function(types){
   let defaultVal = undefined
   if(!Array.isArray(types)){
     types = [types]
-    defaultVal = types
+    defaultVal = types[0]
   }
   
   return {


### PR DESCRIPTION
## Issues resolved:

- [ ] fix crash when using `Utils.actor('user')` with a non-array input

<!-- 
## Screenshot (optional)
 

## Test (optional)

-->
